### PR TITLE
add the main module details

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,8 @@ func main() {
 		fmt.Printf("  %s: %s\n", s.Key, s.Value)
 	}
 
+	fmt.Println("Main: ")
+	fmt.Printf("  %s: %s %s\n", i.Main.Path, i.Main.Version, i.Main.Sum)
 	fmt.Println("Dependencies: ")
 	for _, dep := range i.Deps {
 		fmt.Printf("  %s: %s %s\n", dep.Path, dep.Version, dep.Sum)


### PR DESCRIPTION
Adds the `Main` package details (https://pkg.go.dev/runtime/debug#Module):

```
$ buildinfo -binary tink-server
Getting build info for the tink-server binary...
Go version: go1.15
Build Settings:
Main:
  github.com/tinkerbell/tink: (devel)
Dependencies:
  github.com/beorn7/perks: v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
  github.com/docker/distribution: v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
  github.com/golang/protobuf: v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
  github.com/grpc-ecosystem/go-grpc-middleware: v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
  github.com/grpc-ecosystem/go-grpc-prometheus: v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
  github.com/grpc-ecosystem/grpc-gateway: v1.14.6 h1:8ERzHx8aj1Sc47mu9n/AksaKCSWrMchFtkdrS4BIj5o=
  github.com/lib/pq: v1.2.1-0.20191011153232-f91d3411e481 h1:r9fnMM01mkhtfe6QfLrr/90mBVLnJHge2jGeBvApOjk=
  github.com/matttproud/golang_protobuf_extensions: v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
  github.com/opencontainers/go-digest: v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
  github.com/packethost/pkg: v0.0.0-20190410153520-e8e15f4ce770 h1:M/ErkHz96yXYNdcu0G7kX5Qa1HUliL5QczNdA9/0k40=
  github.com/pkg/errors: v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
  github.com/prometheus/client_golang: v1.1.0 h1:BQ53HtBmfOitExawJ6LokA4x8ov/z0SYYb0+HxJfRI8=
  github.com/prometheus/client_model: v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
  github.com/prometheus/common: v0.6.0 h1:kRhiuYSXR3+uv2IbVbZhUxK5zVD/2pp3Gd2PpvPkpEo=
  github.com/prometheus/procfs: v0.0.3 h1:CTwfnzjQ+8dS6MhHHu4YswVAD99sL2wjPqP+VkURmKE=
  github.com/rollbar/rollbar-go: v1.0.2 h1:uA3+z0jq6ka9WUUt9VX/xuiQZXZyWRoeKvkhVvLO9Jc=
  github.com/satori/go.uuid: v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
  go.uber.org/atomic: v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
  go.uber.org/multierr: v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
  go.uber.org/zap: v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
  golang.org/x/net: v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
  golang.org/x/sys: v0.0.0-20200331124033-c3d80250170d h1:nc5K6ox/4lTFbMVSL9WRR81ixkcwXThoiF6yf+R9scA=
  golang.org/x/text: v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
  google.golang.org/genproto: v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
  google.golang.org/grpc: v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
  google.golang.org/protobuf: v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
  gopkg.in/yaml.v2: v2.2.3 h1:fvjTMHxHEw/mxHbtzPi3JCcKXQRAnQTBRo6YCJSVHKI=
```

(I was hoping to dig up the corresponding git shas (or tag from the main package) using archived OCI images. Alas, they are not included here)